### PR TITLE
chore: fix REUSE compliance by annotating missing files in REUSE.toml

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,6 +6,7 @@ SPDX-PackageComment = "The code in this project may include calls to APIs (\"API
 
 [[annotations]]
 path = [
+    ".claude/**",
     ".github/**",
     "action.yml",
     "test-resources/**",
@@ -15,7 +16,8 @@ path = [
     ".husky/**",
     "package-lock.json",
     "configuration.json",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "renovate.json"
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 SAP SE or an SAP affiliate company and pull-request-semver-bumper contributors"


### PR DESCRIPTION
## Summary

Fixes REUSE compliance check failure caused by files missing copyright and licensing information.

## Changes Made

- Added `renovate.json` to the `[[annotations]]` path list in `REUSE.toml`
- Added `.claude/**` to cover Claude Code worktree scratch directories

Both entries inherit the existing `Apache-2.0` license and SAP copyright already applied to other config/tooling files.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`reuse lint` now reports full compliance:
```
Files with copyright information: 159 / 159
Files with license information: 159 / 159
Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings