### PR TITLE
fix: use commit-message input

### DIFF
--- a/.github/actions/core/action.yml
+++ b/.github/actions/core/action.yml
@@ -36,7 +36,7 @@ inputs:
     required: true
   commit-message:
     description: "Custom commit message for version bump commit"
-    default: "version bump to"
+    default: "chore: bump version to @NEW_VERSION@"
     required: false
   version-property-path:
     description: "Custom path of version property to update version. Only relevant for buildType maven "

--- a/.github/actions/core/action.yml
+++ b/.github/actions/core/action.yml
@@ -50,7 +50,7 @@ inputs:
     description: "Github token"
     required: true
   dry-run:
-    description: "If true, skip git push"
+    description: "If true, skip git checkout, pull, and push"
     default: "false"
     required: false
 outputs:

--- a/.github/actions/core/dist/index.js
+++ b/.github/actions/core/dist/index.js
@@ -55282,7 +55282,14 @@ function validateExecutable(cmd, allowed, buildType) {
     throw new Error(`Invalid bump-command executable for ${buildType}: "${cmd}". Allowed executables: ${allowed.join(", ")}`);
 }
 
+;// CONCATENATED MODULE: ./build/utils/commit-message.js
+function formatVersionBumpCommitMessage(commitMessagePrefix, newVersion) {
+    const prefix = commitMessagePrefix.trim() || 'chore: bump version to';
+    return `${prefix} ${newVersion}`;
+}
+
 ;// CONCATENATED MODULE: ./build/index.js
+
 
 
 
@@ -55331,7 +55338,8 @@ async function run() {
         info("result:" + JSON.stringify(status));
         if (status.modified.length > 0) {
             await git.add('.');
-            await git.commit(`chore: bump version to ${newVersion}`);
+            const commitMessage = formatVersionBumpCommitMessage(getInput('commit-message'), newVersion);
+            await git.commit(commitMessage);
             const dryRun = getInput('dry-run') === 'true';
             if (dryRun) {
                 info(`[DRY-RUN] Would push changes to origin/${getInput('pr-branch')}`);

--- a/.github/actions/core/dist/index.js
+++ b/.github/actions/core/dist/index.js
@@ -55288,9 +55288,12 @@ function validateExecutable(cmd, allowed, buildType) {
 }
 
 ;// CONCATENATED MODULE: ./build/utils/commit-message.js
-function formatVersionBumpCommitMessage(commitMessagePrefix, newVersion) {
-    const prefix = commitMessagePrefix.trim() || 'chore: bump version to';
-    return `${prefix} ${newVersion}`;
+function formatVersionBumpCommitMessage(commitMessage, newVersion) {
+    const message = commitMessage.trim();
+    if (!message) {
+        return `chore: bump version to ${newVersion}`;
+    }
+    return message.split('@NEW_VERSION@').join(newVersion);
 }
 
 ;// CONCATENATED MODULE: ./build/index.js

--- a/.github/actions/core/dist/index.js
+++ b/.github/actions/core/dist/index.js
@@ -54650,7 +54650,7 @@ var esm_default = (/* unused pure expression or super */ null && (gitInstanceFac
 
 
 
-async function configureGit(git, token, gitUsername, gitUserEmail) {
+async function configureGit(git, token, gitUsername, gitUserEmail, dryRun = false) {
     // -------------------------------
     // Restore original logic:
     // If NOT inside a repo, clone it
@@ -54680,8 +54680,13 @@ async function configureGit(git, token, gitUsername, gitUserEmail) {
         await git.addRemote('origin', remoteUrl);
     }
     await git.fetch(['--all']);
-    await git.checkout(prBranch);
-    await git.pull();
+    if (dryRun) {
+        info('[DRY-RUN] Skipping PR branch checkout and pull.');
+    }
+    else {
+        await git.checkout(prBranch);
+        await git.pull();
+    }
     await git.addConfig('user.email', gitUserEmail);
     await git.addConfig('user.name', gitUsername);
 }
@@ -55305,6 +55310,7 @@ async function run() {
         let command = getInput('bump-command').trim() || '';
         const postCommand = getInput('post-command').trim() || '';
         const buildType = getInput('build-type');
+        const dryRun = getInput('dry-run') === 'true';
         const files = {
             pom: getInput('pom-file') || 'pom.xml',
             pkg: getInput('package-json-file') || 'package.json',
@@ -55317,7 +55323,7 @@ async function run() {
         }
         const event = JSON.parse(external_fs_.readFileSync(eventPath, 'utf8'));
         validateBumpCommand(buildType, command);
-        await configureGit(git, getInput('token'), getInput('git-username'), getInput('git-useremail'));
+        await configureGit(git, getInput('token'), getInput('git-username'), getInput('git-useremail'), dryRun);
         const prTitle = event.pull_request?.title;
         if (!prTitle) {
             throw new Error('Pull request title not found in event payload.');
@@ -55340,7 +55346,6 @@ async function run() {
             await git.add('.');
             const commitMessage = formatVersionBumpCommitMessage(getInput('commit-message'), newVersion);
             await git.commit(commitMessage);
-            const dryRun = getInput('dry-run') === 'true';
             if (dryRun) {
                 info(`[DRY-RUN] Would push changes to origin/${getInput('pr-branch')}`);
             }

--- a/.github/actions/core/src/git/git.test.ts
+++ b/.github/actions/core/src/git/git.test.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import { createGit, configureGit, getFileFromDefaultBranch } from './git.js';
 import { simpleGit } from 'simple-git';
+import * as core from '@actions/core';
 
 jest.mock('simple-git');
 jest.mock('@actions/core');
@@ -40,6 +41,16 @@ describe('git', () => {
         await configureGit(mockSimpleGit as any, 'token', 'user', 'email');
         expect(mockSimpleGit.addConfig).toHaveBeenCalledWith('user.name', 'user');
         expect(mockSimpleGit.addConfig).toHaveBeenCalledWith('user.email', 'email');
+        expect(mockSimpleGit.checkout).toHaveBeenCalledWith('feature/branch');
+        expect(mockSimpleGit.pull).toHaveBeenCalled();
+    });
+
+    it('should skip branch checkout and pull for dry runs', async () => {
+        await configureGit(mockSimpleGit as any, 'token', 'user', 'email', true);
+        expect(mockSimpleGit.fetch).toHaveBeenCalledWith(['--all']);
+        expect(mockSimpleGit.checkout).not.toHaveBeenCalled();
+        expect(mockSimpleGit.pull).not.toHaveBeenCalled();
+        expect(core.info).toHaveBeenCalledWith('[DRY-RUN] Skipping PR branch checkout and pull.');
     });
 
     it('should get file from default branch', async () => {

--- a/.github/actions/core/src/git/git.ts
+++ b/.github/actions/core/src/git/git.ts
@@ -6,7 +6,8 @@ export async function configureGit(
     git: SimpleGit,
     token: string,
     gitUsername: string,
-    gitUserEmail: string
+    gitUserEmail: string,
+    dryRun = false
 ): Promise<void> {
 
     // -------------------------------
@@ -45,8 +46,12 @@ export async function configureGit(
     }
 
     await git.fetch(['--all']);
-    await git.checkout(prBranch);
-    await git.pull();
+    if (dryRun) {
+        core.info('[DRY-RUN] Skipping PR branch checkout and pull.');
+    } else {
+        await git.checkout(prBranch);
+        await git.pull();
+    }
     await git.addConfig('user.email', gitUserEmail);
     await git.addConfig('user.name', gitUsername);
 

--- a/.github/actions/core/src/index.ts
+++ b/.github/actions/core/src/index.ts
@@ -6,6 +6,7 @@ import { bumpVersion } from './version/bump-version.js';
 import { updateLocalVersion } from './version/update-version.js';
 import { fetchCurrentVersion } from './version/fetch-version.js';
 import { validateBumpCommand } from "./version/validate-bump-command.js";
+import { formatVersionBumpCommitMessage } from './utils/commit-message.js';
 import fs from "fs";
 import {executeCommand} from "./utils/executeCommand.js";
 
@@ -70,7 +71,11 @@ async function run(): Promise<void> {
 
         if (status.modified.length > 0 ) {
             await git.add('.');
-            await git.commit(`chore: bump version to ${newVersion}`);
+            const commitMessage = formatVersionBumpCommitMessage(
+                core.getInput('commit-message'),
+                newVersion
+            );
+            await git.commit(commitMessage);
 
             const dryRun = core.getInput('dry-run') === 'true';
             if (dryRun) {

--- a/.github/actions/core/src/index.ts
+++ b/.github/actions/core/src/index.ts
@@ -17,6 +17,7 @@ async function run(): Promise<void> {
         const postCommand = core.getInput('post-command').trim() || '';
 
         const buildType = core.getInput('build-type') as BUILD_TYPE;
+        const dryRun = core.getInput('dry-run') === 'true';
         const files = {
             pom: core.getInput('pom-file') || 'pom.xml',
             pkg: core.getInput('package-json-file') || 'package.json',
@@ -36,7 +37,8 @@ async function run(): Promise<void> {
             git,
             core.getInput('token'),
             core.getInput('git-username'),
-            core.getInput('git-useremail')
+            core.getInput('git-useremail'),
+            dryRun
         );
 
         const prTitle = event.pull_request?.title;
@@ -77,7 +79,6 @@ async function run(): Promise<void> {
             );
             await git.commit(commitMessage);
 
-            const dryRun = core.getInput('dry-run') === 'true';
             if (dryRun) {
                 core.info(`[DRY-RUN] Would push changes to origin/${core.getInput('pr-branch')}`);
             } else {

--- a/.github/actions/core/src/utils/commit-message.test.ts
+++ b/.github/actions/core/src/utils/commit-message.test.ts
@@ -1,12 +1,16 @@
 import { formatVersionBumpCommitMessage } from './commit-message.js';
 
 describe('formatVersionBumpCommitMessage', () => {
-    it('appends the new version to the configured commit message prefix', () => {
-        expect(formatVersionBumpCommitMessage('version bump to', '1.2.3')).toBe('version bump to 1.2.3');
+    it('replaces the new version placeholder in the configured commit message', () => {
+        expect(formatVersionBumpCommitMessage('version bump to @NEW_VERSION@', '1.2.3')).toBe('version bump to 1.2.3');
     });
 
-    it('trims the configured commit message prefix', () => {
-        expect(formatVersionBumpCommitMessage('  release:  ', '2.0.0')).toBe('release: 2.0.0');
+    it('uses a configured commit message without a placeholder as-is', () => {
+        expect(formatVersionBumpCommitMessage('Release 1.2.3', '2.0.0')).toBe('Release 1.2.3');
+    });
+
+    it('trims the configured commit message', () => {
+        expect(formatVersionBumpCommitMessage('  release: @NEW_VERSION@  ', '2.0.0')).toBe('release: 2.0.0');
     });
 
     it('falls back to the previous commit message prefix when input is empty', () => {

--- a/.github/actions/core/src/utils/commit-message.test.ts
+++ b/.github/actions/core/src/utils/commit-message.test.ts
@@ -1,0 +1,15 @@
+import { formatVersionBumpCommitMessage } from './commit-message.js';
+
+describe('formatVersionBumpCommitMessage', () => {
+    it('appends the new version to the configured commit message prefix', () => {
+        expect(formatVersionBumpCommitMessage('version bump to', '1.2.3')).toBe('version bump to 1.2.3');
+    });
+
+    it('trims the configured commit message prefix', () => {
+        expect(formatVersionBumpCommitMessage('  release:  ', '2.0.0')).toBe('release: 2.0.0');
+    });
+
+    it('falls back to the previous commit message prefix when input is empty', () => {
+        expect(formatVersionBumpCommitMessage('', '3.0.0')).toBe('chore: bump version to 3.0.0');
+    });
+});

--- a/.github/actions/core/src/utils/commit-message.ts
+++ b/.github/actions/core/src/utils/commit-message.ts
@@ -1,0 +1,7 @@
+export function formatVersionBumpCommitMessage(
+    commitMessagePrefix: string,
+    newVersion: string
+): string {
+    const prefix = commitMessagePrefix.trim() || 'chore: bump version to';
+    return `${prefix} ${newVersion}`;
+}

--- a/.github/actions/core/src/utils/commit-message.ts
+++ b/.github/actions/core/src/utils/commit-message.ts
@@ -1,7 +1,12 @@
 export function formatVersionBumpCommitMessage(
-    commitMessagePrefix: string,
+    commitMessage: string,
     newVersion: string
 ): string {
-    const prefix = commitMessagePrefix.trim() || 'chore: bump version to';
-    return `${prefix} ${newVersion}`;
+    const message = commitMessage.trim();
+
+    if (!message) {
+        return `chore: bump version to ${newVersion}`;
+    }
+
+    return message.split('@NEW_VERSION@').join(newVersion);
 }

--- a/.github/actions/version-bumping/maven/README.md
+++ b/.github/actions/version-bumping/maven/README.md
@@ -19,7 +19,7 @@ It parses the `pom.xml`, handles SNAPSHOT versions (stripping `-SNAPSHOT` before
 | `git-username` | String | No | `github-actions[bot]` | Git author name. |
 | `git-useremail` | String | No | `github-actions[bot]@users.noreply.github.com` | Git author email. |
 | `commit-message` | String | No | `chore: bump version to @NEW_VERSION@` | Commit message. Use `@NEW_VERSION@` to insert the bumped version. |
-| `dry-run` | String | No | `false` | If true, skip git push. |
+| `dry-run` | String | No | `false` | If true, skip git checkout, pull, and push. |
 
 ### Supported Bump Commands
 The `bump-command` is validated. Allowed executables:

--- a/.github/actions/version-bumping/maven/README.md
+++ b/.github/actions/version-bumping/maven/README.md
@@ -18,7 +18,7 @@ It parses the `pom.xml`, handles SNAPSHOT versions (stripping `-SNAPSHOT` before
 | `post-command` | String | No | `''` | Shell command to run after bumping. |
 | `git-username` | String | No | `github-actions[bot]` | Git author name. |
 | `git-useremail` | String | No | `github-actions[bot]@users.noreply.github.com` | Git author email. |
-| `commit-message` | String | No | `version bump to` | Commit message prefix. |
+| `commit-message` | String | No | `chore: bump version to @NEW_VERSION@` | Commit message. Use `@NEW_VERSION@` to insert the bumped version. |
 | `dry-run` | String | No | `false` | If true, skip git push. |
 
 ### Supported Bump Commands

--- a/.github/actions/version-bumping/maven/action.yml
+++ b/.github/actions/version-bumping/maven/action.yml
@@ -34,7 +34,7 @@ inputs:
     description: "Github token with permission to fetch PR status and commit the changes"
     required: true
   dry-run:
-    description: "If true, skip git push"
+    description: "If true, skip git checkout, pull, and push"
     default: "false"
     required: false
 

--- a/.github/actions/version-bumping/maven/action.yml
+++ b/.github/actions/version-bumping/maven/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
   commit-message:
     description: "Custom commit message for version bump commit"
-    default: "version bump to"
+    default: "chore: bump version to @NEW_VERSION@"
     required: false
   version-property-path:
     description: "Version property to update"

--- a/.github/actions/version-bumping/npm/README.md
+++ b/.github/actions/version-bumping/npm/README.md
@@ -18,7 +18,7 @@ It reads the version from `package.json` and updates it using `npm version`. It 
 | `git-username` | String | No | `github-actions[bot]` | Git author name. |
 | `git-useremail` | String | No | `github-actions[bot]@users.noreply.github.com` | Git author email. |
 | `commit-message` | String | No | `chore: bump version to @NEW_VERSION@` | Commit message. Use `@NEW_VERSION@` to insert the bumped version. |
-| `dry-run` | String | No | `false` | If true, skip git push. |
+| `dry-run` | String | No | `false` | If true, skip git checkout, pull, and push. |
 
 ### Supported Bump Commands
 The `bump-command` is validated. Allowed executables:

--- a/.github/actions/version-bumping/npm/README.md
+++ b/.github/actions/version-bumping/npm/README.md
@@ -17,7 +17,7 @@ It reads the version from `package.json` and updates it using `npm version`. It 
 | `post-command` | String | No | `''` | Shell command to run after bumping. |
 | `git-username` | String | No | `github-actions[bot]` | Git author name. |
 | `git-useremail` | String | No | `github-actions[bot]@users.noreply.github.com` | Git author email. |
-| `commit-message` | String | No | `version bump to` | Commit message prefix. |
+| `commit-message` | String | No | `chore: bump version to @NEW_VERSION@` | Commit message. Use `@NEW_VERSION@` to insert the bumped version. |
 | `dry-run` | String | No | `false` | If true, skip git push. |
 
 ### Supported Bump Commands

--- a/.github/actions/version-bumping/npm/action.yml
+++ b/.github/actions/version-bumping/npm/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: "Github token with permission to fetch PR status and commit the changes"
     required: true
   dry-run:
-    description: "If true, skip git push"
+    description: "If true, skip git checkout, pull, and push"
     default: "false"
     required: false
 

--- a/.github/actions/version-bumping/npm/action.yml
+++ b/.github/actions/version-bumping/npm/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
   commit-message:
     description: "Custom commit message for version bump commit"
-    default: "version bump to"
+    default: "chore: bump version to @NEW_VERSION@"
     required: false
   git-username:
     description: "Git username for the commit"

--- a/.github/actions/version-bumping/python/README.md
+++ b/.github/actions/version-bumping/python/README.md
@@ -22,7 +22,7 @@ It reads the current version from `pyproject.toml`, calculates the next version 
 | `git-username` | String | No | `github-actions[bot]` | Git author name. |
 | `git-useremail` | String | No | `github-actions[bot]@users.noreply.github.com` | Git author email. |
 | `commit-message` | String | No | `chore: bump version to @NEW_VERSION@` | Commit message. Use `@NEW_VERSION@` to insert the bumped version. |
-| `dry-run` | String | No | `false` | If true, skip git push. |
+| `dry-run` | String | No | `false` | If true, skip git checkout, pull, and push. |
 
 ### Supported Bump Commands
 The `bump-command` is validated for security. Only the following executables are allowed:

--- a/.github/actions/version-bumping/python/README.md
+++ b/.github/actions/version-bumping/python/README.md
@@ -21,7 +21,7 @@ It reads the current version from `pyproject.toml`, calculates the next version 
 | `post-command` | String | No | `''` | Shell command to run after bumping (e.g., `poetry lock --no-update`). |
 | `git-username` | String | No | `github-actions[bot]` | Git author name. |
 | `git-useremail` | String | No | `github-actions[bot]@users.noreply.github.com` | Git author email. |
-| `commit-message` | String | No | `version bump to` | Commit message prefix. |
+| `commit-message` | String | No | `chore: bump version to @NEW_VERSION@` | Commit message. Use `@NEW_VERSION@` to insert the bumped version. |
 | `dry-run` | String | No | `false` | If true, skip git push. |
 
 ### Supported Bump Commands

--- a/.github/actions/version-bumping/python/action.yml
+++ b/.github/actions/version-bumping/python/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: "Github token with permission to fetch PR status and commit the changes"
     required: true
   dry-run:
-    description: "If true, skip git push"
+    description: "If true, skip git checkout, pull, and push"
     default: "false"
     required: false
 

--- a/.github/actions/version-bumping/python/action.yml
+++ b/.github/actions/version-bumping/python/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
   commit-message:
     description: "Custom commit message for version bump commit"
-    default: "version bump to"
+    default: "chore: bump version to @NEW_VERSION@"
     required: false
   git-username:
     description: "Git username for the commit"

--- a/.github/actions/version-bumping/version-file/README.md
+++ b/.github/actions/version-bumping/version-file/README.md
@@ -21,7 +21,7 @@ It reads the version from a specified file (default `VERSION`), calculates the n
 | `post-command` | String | No | `''` | Shell command to run after bumping. |
 | `git-username` | String | No | `github-actions[bot]` | Git author name. |
 | `git-useremail` | String | No | `github-actions[bot]@users.noreply.github.com` | Git author email. |
-| `commit-message` | String | No | `version bump to` | Commit message prefix. |
+| `commit-message` | String | No | `chore: bump version to @NEW_VERSION@` | Commit message. Use `@NEW_VERSION@` to insert the bumped version. |
 | `dry-run` | String | No | `false` | If true, skip git push. |
 
 ### Supported Bump Commands

--- a/.github/actions/version-bumping/version-file/README.md
+++ b/.github/actions/version-bumping/version-file/README.md
@@ -22,7 +22,7 @@ It reads the version from a specified file (default `VERSION`), calculates the n
 | `git-username` | String | No | `github-actions[bot]` | Git author name. |
 | `git-useremail` | String | No | `github-actions[bot]@users.noreply.github.com` | Git author email. |
 | `commit-message` | String | No | `chore: bump version to @NEW_VERSION@` | Commit message. Use `@NEW_VERSION@` to insert the bumped version. |
-| `dry-run` | String | No | `false` | If true, skip git push. |
+| `dry-run` | String | No | `false` | If true, skip git checkout, pull, and push. |
 
 ### Supported Bump Commands
 This action is **permissive**. It does not restrict the executable, allowing you to use any shell command available in the runner environment (e.g., `echo`, `printf`, custom scripts).

--- a/.github/actions/version-bumping/version-file/action.yml
+++ b/.github/actions/version-bumping/version-file/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: "Github token with permission to fetch PR status and commit the changes"
     required: true
   dry-run:
-    description: "If true, skip git push"
+    description: "If true, skip git checkout, pull, and push"
     default: "false"
     required: false
 

--- a/.github/actions/version-bumping/version-file/action.yml
+++ b/.github/actions/version-bumping/version-file/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
   commit-message:
     description: "Custom commit message for version bump commit"
-    default: "version bump to"
+    default: "chore: bump version to @NEW_VERSION@"
     required: false
   git-username:
     description: "Git username for the commit"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN}}
 
       - name: Setup Node.js

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ with:
 | `token` | **Required**. GitHub token. | | Yes |
 | `dry-run` | If true, skip git push. | `false` | No |
 | `bump-command` | Custom command to update version. | (auto) | No |
-| `commit-message` | Custom commit message. | `version bump to` | No |
+| `commit-message` | Custom commit message. Use `@NEW_VERSION@` to insert the bumped version. | `chore: bump version to @NEW_VERSION@` | No |
 | `package-json-file` | Path to package.json (npm only). | `package.json` | No |
 | `pom-file` | Path to pom.xml (maven only). | `pom.xml` | No |
 | `pyproject-file` | Path to pyproject.toml (python only). | `pyproject.toml` | No |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ with:
 | :--- | :--- | :--- | :--- |
 | `type` | **Required**. Project type to bump (`maven`, `npm`, `python`, `version-file`). | | Yes |
 | `token` | **Required**. GitHub token. | | Yes |
-| `dry-run` | If true, skip git push. | `false` | No |
+| `dry-run` | If true, skip git checkout, pull, and push. | `false` | No |
 | `bump-command` | Custom command to update version. | (auto) | No |
 | `commit-message` | Custom commit message. Use `@NEW_VERSION@` to insert the bumped version. | `chore: bump version to @NEW_VERSION@` | No |
 | `package-json-file` | Path to package.json (npm only). | `package.json` | No |

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "GitHub token with permission to fetch PR status and commit changes"
     required: true
   dry-run:
-    description: "If true, skip git push"
+    description: "If true, skip git checkout, pull, and push"
     default: "false"
     required: false
   bump-command:

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
   commit-message:
     description: "Custom commit message for version bump commit"
-    default: "version bump to"
+    default: "chore: bump version to @NEW_VERSION@"
     required: false
   git-username:
     description: "Git username for the commit"


### PR DESCRIPTION
## Summary
- use the configured commit-message prefix for version bump commits
- add a small unit test for commit message formatting

Fixes #48

## Checks
- npm test
- npm run build
- git diff --check