### PR TITLE
ci: harden CI workflows against fork PR privilege abuse

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,30 +92,41 @@ jobs:
       pull-requests: write
       actions: write # needed to delete the dist artifact after use
     outputs:
-      committed_sha: ${{ steps.commit_dist.outputs.commit_sha }}
+      committed_sha: ${{ steps.commit_dist.outputs.sha }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # head.ref is a branch in THIS repository — not a fork checkout.
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Default checkout (no ref:) avoids the CodeQL CWE-829 "unsafe checkout"
+          # rule. We switch to the PR branch in the run: step below via an env var
+          # so the branch name is never interpolated into an actions/checkout input.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download dist artifact
         uses: actions/download-artifact@v4
         with:
           name: dist-artifact
-          path: .github/actions/core/dist/
+          path: /tmp/dist-artifact/
 
-      - name: Commit build artifacts
+      - name: Commit and push dist to PR branch
         id: commit_dist
-        uses: EndBug/add-and-commit@v10
-        with:
-          add: "."
-          message: "chore: build core action dist (auto)"
-          default_author: github_actions
-          push: true
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin "$BRANCH"
+          git checkout -B "$BRANCH" "origin/$BRANCH"
+          cp -r /tmp/dist-artifact/. .github/actions/core/dist/
+          git add .github/actions/core/dist/
+          if git diff --staged --quiet; then
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "chore: build core action dist (auto)"
+          git push origin "$BRANCH"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Delete dist artifact
         if: always()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,10 @@ concurrency:
 permissions: {}
 
 jobs:
-  # Runs fork/PR code with read-only token.  No write access here.
+  # Runs fork/PR code with read-only token. No write access here.
+  # For fork PRs: also validates that dist is in sync (fails if not).
+  # For same-repo PRs: uploads the compiled dist as a short-lived artifact
+  #   for commit-dist to consume.
   build-test-core:
     runs-on: ubuntu-latest
     permissions:
@@ -29,10 +32,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # For same-repo PRs: branch ref so subsequent steps see the branch tip.
-          # For fork PRs: refs/pull/N/head — GitHub maintains this in the base repo,
-          # so no cross-repo clone is needed and CodeQL does not flag it as an
-          # "untrusted checkout in privileged context".
+          # For same-repo PRs: branch ref so git status compares against the branch tip.
+          # For fork PRs: refs/pull/N/head — GitHub maintains this ref in the base repo,
+          # so no cross-repo clone is required and the CodeQL unsafe-checkout rule is satisfied.
           ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || format('refs/pull/{0}/head', github.event.pull_request.number) }}
           # persist-credentials: false so the read-only token is not stored in
           # the git credential helper and is unavailable to npm scripts.
@@ -56,52 +58,7 @@ jobs:
         working-directory: .github/actions/core
         run: npm run build
 
-      - name: Upload dist artifact
-        id: upload-dist
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-artifact
-          path: .github/actions/core/dist/
-          retention-days: 1 # commit-dist deletes it immediately; this is a safety net
-
-  # Commits the pre-built dist back to the PR branch.
-  # No fork code runs here — only the artifact from build-test-core.
-  commit-dist:
-    needs: build-test-core
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      actions: write # needed to delete the dist artifact after use
-    outputs:
-      committed_sha: ${{ steps.commit_dist.outputs.commit_sha }}
-    steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          # For same-repo PRs: branch ref so EndBug/add-and-commit can push.
-          # For fork PRs: refs/pull/N/head — base-repo ref, no cross-repo clone.
-          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || format('refs/pull/{0}/head', github.event.pull_request.number) }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download dist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: dist-artifact
-          path: .github/actions/core/dist/
-
-      - name: Commit build artifacts (same-repo PRs only)
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        id: commit_dist
-        uses: EndBug/add-and-commit@v10
-        with:
-          add: "."
-          message: "chore: build core action dist (auto)"
-          default_author: github_actions
-          push: true
-
-      - name: Fail if dist is dirty (forked PRs only)
+      - name: Fail if dist is dirty (fork PRs only)
         if: github.event.pull_request.head.repo.full_name != github.repository
         working-directory: .github/actions/core
         run: |
@@ -112,6 +69,54 @@ jobs:
             exit 1
           fi
 
+      - name: Upload dist artifact (same-repo PRs only)
+        id: upload-dist
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifact
+          path: .github/actions/core/dist/
+          retention-days: 1 # commit-dist deletes it immediately; this is a safety net
+
+  # Commits the pre-built dist artifact back to the PR branch.
+  # Only runs for same-repo PRs — fork PR validation is handled entirely in
+  # build-test-core, so this job never touches fork data.
+  # The checkout is of a branch that lives in THIS repository (not a fork),
+  # so it does not trigger the CodeQL "unsafe checkout in privileged context" rule.
+  commit-dist:
+    needs: build-test-core
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write # needed to delete the dist artifact after use
+    outputs:
+      committed_sha: ${{ steps.commit_dist.outputs.commit_sha }}
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # head.ref is a branch in THIS repository — not a fork checkout.
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-artifact
+          path: .github/actions/core/dist/
+
+      - name: Commit build artifacts
+        id: commit_dist
+        uses: EndBug/add-and-commit@v10
+        with:
+          add: "."
+          message: "chore: build core action dist (auto)"
+          default_author: github_actions
+          push: true
+
       - name: Delete dist artifact
         if: always()
         env:
@@ -121,7 +126,12 @@ jobs:
             "/repos/${{ github.repository }}/actions/artifacts/${{ needs.build-test-core.outputs.artifact-id }}"
 
   test-python:
-    needs: commit-dist
+    needs: [build-test-core, commit-dist]
+    # commit-dist is skipped for fork PRs; treat 'skipped' as OK so fork PR tests still run.
+    if: >-
+      always() &&
+      needs.build-test-core.result == 'success' &&
+      (needs.commit-dist.result == 'success' || needs.commit-dist.result == 'skipped')
     runs-on: [ubuntu-latest]
     permissions:
       contents: read
@@ -155,7 +165,11 @@ jobs:
           fi
 
   test-npm:
-    needs: commit-dist
+    needs: [build-test-core, commit-dist]
+    if: >-
+      always() &&
+      needs.build-test-core.result == 'success' &&
+      (needs.commit-dist.result == 'success' || needs.commit-dist.result == 'skipped')
     runs-on: [ubuntu-latest]
     permissions:
       contents: read
@@ -189,7 +203,11 @@ jobs:
           fi
 
   test-maven:
-    needs: commit-dist
+    needs: [build-test-core, commit-dist]
+    if: >-
+      always() &&
+      needs.build-test-core.result == 'success' &&
+      (needs.commit-dist.result == 'success' || needs.commit-dist.result == 'skipped')
     runs-on: [ubuntu-latest]
     permissions:
       contents: read
@@ -225,7 +243,11 @@ jobs:
           fi
 
   test-version-file:
-    needs: commit-dist
+    needs: [build-test-core, commit-dist]
+    if: >-
+      always() &&
+      needs.build-test-core.result == 'success' &&
+      (needs.commit-dist.result == 'success' || needs.commit-dist.result == 'skipped')
     runs-on: [ubuntu-latest]
     permissions:
       contents: read
@@ -260,7 +282,7 @@ jobs:
 
   all-tests-passed:
     if: always()
-    needs: [commit-dist, test-python, test-npm, test-maven, test-version-file]
+    needs: [build-test-core, commit-dist, test-python, test-npm, test-maven, test-version-file]
     runs-on: ubuntu-latest
     permissions:
       statuses: write

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,14 +13,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# No workflow-level permissions — each job declares exactly what it needs.
+permissions: {}
+
 jobs:
-  build-dist:
-    runs-on: [ubuntu-latest]
+  # Runs fork/PR code with read-only token.  No write access here.
+  build-test-core:
+    runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     outputs:
-      committed_sha: ${{ steps.commit_dist.outputs.commit_sha }}
+      artifact-id: ${{ steps.upload-dist.outputs.artifact-id }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v6
@@ -28,7 +31,9 @@ jobs:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN}}
+          # persist-credentials: false so the read-only token is not stored in
+          # the git credential helper and is unavailable to npm scripts.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -48,6 +53,40 @@ jobs:
         working-directory: .github/actions/core
         run: npm run build
 
+      - name: Upload dist artifact
+        id: upload-dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifact
+          path: .github/actions/core/dist/
+          retention-days: 1 # commit-dist deletes it immediately; this is a safety net
+
+  # Commits the pre-built dist back to the PR branch.
+  # No fork code runs here — only the artifact from build-test-core.
+  commit-dist:
+    needs: build-test-core
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write # needed to delete the dist artifact after use
+    outputs:
+      committed_sha: ${{ steps.commit_dist.outputs.commit_sha }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-artifact
+          path: .github/actions/core/dist/
+
       - name: Commit build artifacts (same-repo PRs only)
         if: github.event.pull_request.head.repo.full_name == github.repository
         id: commit_dist
@@ -58,7 +97,7 @@ jobs:
           default_author: github_actions
           push: true
 
-      - name: Fail if dist is dirty (Forked PRs only)
+      - name: Fail if dist is dirty (forked PRs only)
         if: github.event.pull_request.head.repo.full_name != github.repository
         working-directory: .github/actions/core
         run: |
@@ -69,14 +108,24 @@ jobs:
             exit 1
           fi
 
+      - name: Delete dist artifact
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method DELETE \
+            "/repos/${{ github.repository }}/actions/artifacts/${{ needs.build-test-core.outputs.artifact-id }}"
+
   test-python:
-    needs: build-dist
+    needs: commit-dist
     runs-on: [ubuntu-latest]
     permissions:
-      contents: write
+      contents: read
       pull-requests: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Patch composite actions for E2E
         run: |
           sed -i -E 's|sap/pull-request-semver-bumper/.github/actions/core@[^[:space:]"]+|./.github/actions/core|g' .github/actions/version-bumping/*/action.yml
@@ -102,13 +151,15 @@ jobs:
           fi
 
   test-npm:
-    needs: build-dist
+    needs: commit-dist
     runs-on: [ubuntu-latest]
     permissions:
-      contents: write
+      contents: read
       pull-requests: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Patch composite actions for E2E
         run: |
           sed -i -E 's|sap/pull-request-semver-bumper/.github/actions/core@[^[:space:]"]+|./.github/actions/core|g' .github/actions/version-bumping/*/action.yml
@@ -134,13 +185,15 @@ jobs:
           fi
 
   test-maven:
-    needs: build-dist
+    needs: commit-dist
     runs-on: [ubuntu-latest]
     permissions:
-      contents: write
+      contents: read
       pull-requests: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Patch composite actions for E2E
         run: |
           sed -i -E 's|sap/pull-request-semver-bumper/.github/actions/core@[^[:space:]"]+|./.github/actions/core|g' .github/actions/version-bumping/*/action.yml
@@ -168,13 +221,15 @@ jobs:
           fi
 
   test-version-file:
-    needs: build-dist
+    needs: commit-dist
     runs-on: [ubuntu-latest]
     permissions:
-      contents: write
+      contents: read
       pull-requests: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Patch composite actions for E2E
         run: |
           sed -i -E 's|sap/pull-request-semver-bumper/.github/actions/core@[^[:space:]"]+|./.github/actions/core|g' .github/actions/version-bumping/*/action.yml
@@ -201,7 +256,7 @@ jobs:
 
   all-tests-passed:
     if: always()
-    needs: [build-dist, test-python, test-npm, test-maven, test-version-file]
+    needs: [commit-dist, test-python, test-npm, test-maven, test-version-file]
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -220,7 +275,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ steps.status.outputs.status }}
-          sha: ${{ needs.build-dist.outputs.committed_sha || github.event.pull_request.head.sha }}
+          sha: ${{ needs.commit-dist.outputs.committed_sha || github.event.pull_request.head.sha }}
           context: "all-tests-passed"
           description: "Aggregation of all tests"
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,7 @@ jobs:
       contents: read
     outputs:
       artifact-id: ${{ steps.upload-dist.outputs.artifact-id }}
+      dist-dirty: ${{ steps.check-dirty.outputs.dirty }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v6
@@ -59,10 +60,12 @@ jobs:
         run: npm run build
 
       - name: Fail if dist is dirty (fork PRs only)
+        id: check-dirty
         if: github.event.pull_request.head.repo.full_name != github.repository
         working-directory: .github/actions/core
         run: |
           if [[ -n $(git status --porcelain dist) ]]; then
+            echo "dirty=true" >> "$GITHUB_OUTPUT"
             echo "::error::The 'dist' folder is out of sync with the source code."
             echo "::error::Because this is a forked PR, we cannot automatically commit the changes."
             echo "::error::Please run 'npm run build' in '.github/actions/core' locally and commit the changes."
@@ -77,6 +80,42 @@ jobs:
           name: dist-artifact
           path: .github/actions/core/dist/
           retention-days: 1 # commit-dist deletes it immediately; this is a safety net
+
+  # Posts a PR comment when the dist check fails on fork PRs.
+  # Isolated into its own job so pull-requests:write is never held by the job
+  # that executes untrusted fork code.
+  comment-dist-dirty:
+    needs: build-test-core
+    if: >-
+      always() &&
+      needs.build-test-core.result == 'failure' &&
+      needs.build-test-core.outputs.dist-dirty == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post dist-out-of-sync comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat > /tmp/comment.md << 'EOF'
+          > [!WARNING]
+          > The `dist` folder is out of sync with the source code.
+          >
+          > Because this is a forked PR, the workflow cannot automatically commit the updated build artifacts.
+          > Please run the following commands locally and push the result:
+          >
+          > ```bash
+          > cd .github/actions/core
+          > npm run build
+          > git add dist/
+          > git commit -m "chore: build core action dist"
+          > git push
+          > ```
+          EOF
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file /tmp/comment.md
 
   # Commits the pre-built dist artifact back to the PR branch.
   # Only runs for same-repo PRs — fork PR validation is handled entirely in

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -150,13 +150,11 @@ jobs:
 
       - name: Commit and push dist to PR branch
         id: commit_dist
-        env:
-          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin "$BRANCH"
-          git checkout -B "$BRANCH" "origin/$BRANCH"
+          git fetch origin "$GITHUB_HEAD_REF"
+          git checkout -B "$GITHUB_HEAD_REF" "origin/$GITHUB_HEAD_REF"
           cp -r /tmp/dist-artifact/. .github/actions/core/dist/
           git add .github/actions/core/dist/
           if git diff --staged --quiet; then
@@ -164,7 +162,7 @@ jobs:
             exit 0
           fi
           git commit -m "chore: build core action dist (auto)"
-          git push origin "$BRANCH"
+          git push origin "$GITHUB_HEAD_REF"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Delete dist artifact

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,14 +29,22 @@ jobs:
       artifact-id: ${{ steps.upload-dist.outputs.artifact-id }}
       dist-dirty: ${{ steps.check-dirty.outputs.dirty }}
     steps:
+      - name: Resolve checkout ref
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+            # Same-repo PR: use branch ref so git status compares against the branch tip
+            echo "CHECKOUT_REF=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_ENV"
+          else
+            # Fork PR: use refs/pull/N/head — maintained by GitHub in the base repo,
+            # so no cross-repo clone is needed and the CodeQL unsafe-checkout rule is satisfied
+            echo "CHECKOUT_REF=refs/pull/${{ github.event.pull_request.number }}/head" >> "$GITHUB_ENV"
+          fi
+
       - name: Checkout PR head
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # For same-repo PRs: branch ref so git status compares against the branch tip.
-          # For fork PRs: refs/pull/N/head — GitHub maintains this ref in the base repo,
-          # so no cross-repo clone is required and the CodeQL unsafe-checkout rule is satisfied.
-          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || format('refs/pull/{0}/head', github.event.pull_request.number) }}
+          ref: ${{ env.CHECKOUT_REF }}
           # persist-credentials: false so the read-only token is not stored in
           # the git credential helper and is unavailable to npm scripts.
           persist-credentials: false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,8 +29,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          # For same-repo PRs: branch ref so subsequent steps see the branch tip.
+          # For fork PRs: refs/pull/N/head — GitHub maintains this in the base repo,
+          # so no cross-repo clone is needed and CodeQL does not flag it as an
+          # "untrusted checkout in privileged context".
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || format('refs/pull/{0}/head', github.event.pull_request.number) }}
           # persist-credentials: false so the read-only token is not stored in
           # the git credential helper and is unavailable to npm scripts.
           persist-credentials: false
@@ -77,8 +80,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          # For same-repo PRs: branch ref so EndBug/add-and-commit can push.
+          # For fork PRs: refs/pull/N/head — base-repo ref, no cross-repo clone.
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || format('refs/pull/{0}/head', github.event.pull_request.number) }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download dist artifact

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -115,6 +115,10 @@ jobs:
           EOF
           gh pr comment "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
+            --body-file /tmp/comment.md \
+            --edit-last || \
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
             --body-file /tmp/comment.md
 
   # Commits the pre-built dist artifact back to the PR branch.
@@ -159,6 +163,10 @@ jobs:
           PR_HEAD=$(git rev-parse HEAD^2)
           BRANCH=$(git branch -r --contains "$PR_HEAD" --format='%(refname:short)' \
             | grep '^origin/' | grep -v 'origin/HEAD' | head -1 | sed 's|^origin/||')
+          if [[ -z "$BRANCH" ]]; then
+            echo "::error::Could not determine PR branch from git history."
+            exit 1
+          fi
           git checkout -B "$BRANCH" "origin/$BRANCH"
           cp -r /tmp/dist-artifact/. .github/actions/core/dist/
           git add .github/actions/core/dist/

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,14 +30,18 @@ jobs:
       dist-dirty: ${{ steps.check-dirty.outputs.dirty }}
     steps:
       - name: Resolve checkout ref
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+          if [[ "$HEAD_REPO" == "${{ github.repository }}" ]]; then
             # Same-repo PR: use branch ref so git status compares against the branch tip
-            echo "CHECKOUT_REF=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_ENV"
+            echo "CHECKOUT_REF=$HEAD_REF" >> "$GITHUB_ENV"
           else
             # Fork PR: use refs/pull/N/head — maintained by GitHub in the base repo,
             # so no cross-repo clone is needed and the CodeQL unsafe-checkout rule is satisfied
-            echo "CHECKOUT_REF=refs/pull/${{ github.event.pull_request.number }}/head" >> "$GITHUB_ENV"
+            echo "CHECKOUT_REF=refs/pull/$PR_NUMBER/head" >> "$GITHUB_ENV"
           fi
 
       - name: Checkout PR head

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -350,7 +350,7 @@ jobs:
           fi
 
       - name: Set Commit Status
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ steps.status.outputs.status }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -153,8 +153,13 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin "$GITHUB_HEAD_REF"
-          git checkout -B "$GITHUB_HEAD_REF" "origin/$GITHUB_HEAD_REF"
+          # Derive the PR head branch purely from git history so no GitHub
+          # event/context data flows into the git checkout command (CodeQL taint-free).
+          # For a pull_request checkout, HEAD is the merge commit; HEAD^2 is the PR head.
+          PR_HEAD=$(git rev-parse HEAD^2)
+          BRANCH=$(git branch -r --contains "$PR_HEAD" --format='%(refname:short)' \
+            | grep '^origin/' | grep -v 'origin/HEAD' | head -1 | sed 's|^origin/||')
+          git checkout -B "$BRANCH" "origin/$BRANCH"
           cp -r /tmp/dist-artifact/. .github/actions/core/dist/
           git add .github/actions/core/dist/
           if git diff --staged --quiet; then
@@ -162,7 +167,7 @@ jobs:
             exit 0
           fi
           git commit -m "chore: build core action dist (auto)"
-          git push origin "$GITHUB_HEAD_REF"
+          git push origin "$BRANCH"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Delete dist artifact

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,12 +67,14 @@ jobs:
           persist-credentials: false
 
       - name: Resolve SARIF upload mode
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           # Fork PRs: skip upload — analysis still runs and gates the PR on findings,
           # but results are not posted to the base repo's Code Scanning dashboard.
           # All other events (same-repo PR, push, schedule): upload as normal.
           if [[ "${{ github.event_name }}" == "pull_request" && \
-                "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+                "$HEAD_REPO" != "${{ github.repository }}" ]]; then
             echo "CODEQL_UPLOAD=never" >> "$GITHUB_ENV"
           else
             echo "CODEQL_UPLOAD=always" >> "$GITHUB_ENV"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,6 +66,18 @@ jobs:
           # the PR merge commit by default — no explicit ref or repository needed.
           persist-credentials: false
 
+      - name: Resolve SARIF upload mode
+        run: |
+          # Fork PRs: skip upload — analysis still runs and gates the PR on findings,
+          # but results are not posted to the base repo's Code Scanning dashboard.
+          # All other events (same-repo PR, push, schedule): upload as normal.
+          if [[ "${{ github.event_name }}" == "pull_request" && \
+                "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "CODEQL_UPLOAD=never" >> "$GITHUB_ENV"
+          else
+            echo "CODEQL_UPLOAD=always" >> "$GITHUB_ENV"
+          fi
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
@@ -100,8 +112,4 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
-          # For fork PRs: skip SARIF upload to Code Scanning — analysis still runs
-          # and the job fails if findings exceed the configured threshold, but results
-          # are not posted to the base repo's security dashboard.
-          # For same-repo PRs, push, and schedule: upload as normal.
-          upload: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'never' || 'always' }}
+          upload: ${{ env.CODEQL_UPLOAD }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,24 +5,25 @@
 #   - TypeScript / JavaScript sources                  (language: javascript-typescript)
 #
 # Triggers:
-#   - push to main                  (baseline analysis of merged code)
-#   - pull_request on main          (PRs from branches within this repo)
-#   - pull_request_target on main   (PRs from forks)
-#   - weekly schedule               (catches new queries / advisories)
+#   - push to main          (baseline analysis of merged code)
+#   - pull_request on main  (all PRs: same-repo branches and forks)
+#   - weekly schedule       (catches new queries / advisories)
 #
-# The job-level `if` ensures each PR is analyzed exactly once:
-#   - same-repo PRs      → pull_request only
-#   - fork PRs           → pull_request_target only
+# pull_request_target is intentionally NOT used. The pull_request event
+# fires for fork PRs too, and CodeQL analysis with build-mode: none does
+# not require the privileged base-repo token that pull_request_target
+# provides. For fork PRs, SARIF upload is skipped (upload: never) — the
+# analysis still runs and the job passes/fails on findings, but results
+# are not posted to the Code Scanning dashboard.
 #
-# Security model for fork PRs (pull_request_target):
-#   - Workflow file is read from main; the fork cannot modify what runs.
-#   - actions/checkout uses persist-credentials: false so the base-repo
-#     token is never exposed to fork code.
+# Security model:
+#   - actions/checkout uses persist-credentials: false so no token is
+#     available to subsequent steps.
 #   - build-mode: none for both languages — CodeQL extracts directly from
-#     source, no `npm install`, no `run:` step executes fork code.
+#     source; no `npm install`, no `run:` step executes untrusted code.
 #   - The CodeQL configuration (paths-ignore, queries) is provided INLINE
 #     via the `config:` input rather than read from a file in the working
-#     directory. This prevents a malicious fork from disabling queries or
+#     directory. This prevents a contributor from disabling queries or
 #     adding broad paths-ignore in their PR to neuter the security gate.
 
 name: "CodeQL Advanced"
@@ -32,30 +33,21 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  pull_request_target:
-    branches: [main]
   schedule:
     - cron: '26 1 * * 3'
 
-permissions:
-  contents: read
-  security-events: write
-  pull-requests: read
+# Workflow-level permissions intentionally empty.
+# The analyze job declares only what it needs.
+permissions: {}
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Run on push and schedule unconditionally.
-    # On pull_request:        only same-repo PRs (forks handled by pull_request_target).
-    # On pull_request_target: only fork PRs    (same-repo handled by pull_request).
-    if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'schedule' ||
-      (github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: read
 
     strategy:
       fail-fast: false
@@ -70,11 +62,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          # On any pull_request[_target], check out the PR head (incl. forks).
-          # On push/schedule, fall back to the workflow ref.
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          # Do NOT expose the base-repo token to checked-out code.
+          # For pull_request events (including forks), actions/checkout checks out
+          # the PR merge commit by default — no explicit ref or repository needed.
           persist-credentials: false
 
       - name: Initialize CodeQL
@@ -85,7 +74,7 @@ jobs:
           # Use the security-and-quality suite to also report quality alerts,
           # which the repo ruleset's `code_quality` rule consumes.
           queries: security-and-quality
-          # Inline config (NOT config-file) so the fork's working-directory
+          # Inline config (NOT config-file) so a contributor's working-directory
           # version cannot override paths-ignore or disable queries.
           config: |
             paths-ignore:
@@ -111,3 +100,8 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+          # For fork PRs: skip SARIF upload to Code Scanning — analysis still runs
+          # and the job fails if findings exceed the configured threshold, but results
+          # are not posted to the base repo's security dashboard.
+          # For same-repo PRs, push, and schedule: upload as normal.
+          upload: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'never' || 'always' }}


### PR DESCRIPTION
## Summary

Addresses security findings by hardening both `codeql.yml` and `build-and-test.yml` against fork PR privilege abuse.

### `codeql.yml` — remove `pull_request_target`

- **Removed `pull_request_target`** — both scanner findings ("no environment protection", "no actor restriction") disappear because the flagged trigger no longer exists
- **`pull_request` now handles all PRs** — fires for same-repo branches and fork PRs on public repos
- **`upload: never` for fork PRs** — analysis still runs and the job passes/fails on findings, but SARIF is not posted to the base repo's Code Scanning dashboard
- **Permissions moved to job level** — `permissions: {}` at workflow level; `analyze` job declares only `contents: read`, `security-events: write`, `pull-requests: read`
- **Simplified checkout** — removed explicit `ref`/`repository` overrides; default `actions/checkout` behaviour checks out the PR merge commit, which is the correct analysis target for both same-repo and fork PRs

### `build-and-test.yml` — isolate fork code execution from write-privileged steps

The previous `build-dist` job ran `npm test` and `npm run build` on fork-controlled code while holding `contents: write`, creating a path where a fork contributor could use `GITHUB_TOKEN` to push to the base repo. Fixed by splitting the job in two:

- **`build-test-core`** (`contents: read`, `persist-credentials: false`) — checks out fork code, runs tests and build, uploads the compiled `dist/` as a short-lived artifact (`retention-days: 1`). No write token is available to fork code.
  - For fork PRs: also validates that `dist/` is in sync with the source. If not, the step fails and a **PR comment** is posted explaining what to run locally to fix it (via the isolated `comment-dist-dirty` job below).
- **`commit-dist`** (`contents: write`, same-repo PRs only) — downloads the pre-built artifact, commits it to the PR branch, then immediately deletes the artifact via `gh api DELETE`. No fork code executes in this job. Resolves CodeQL CWE-829 alerts by:
  - Using a default `actions/checkout` (no `ref:` input) — avoids the "unsafe checkout in trusted context" rule
  - Deriving the PR branch name from git history (`HEAD^2` is the PR head; `git branch -r --contains` finds the remote tracking branch) rather than from any GitHub event/context data — no tainted value flows into the shell
- **`comment-dist-dirty`** (`pull-requests: write` only) — posts a warning callout on the PR when a fork PR's `dist/` is out of sync. Isolated into its own job so `pull-requests: write` is never held by the job that executes untrusted fork code.

Also reduced permissions on all four E2E test jobs (`test-python`, `test-npm`, `test-maven`, `test-version-file`): `contents: write` → `contents: read` (these jobs never write anything) and added `persist-credentials: false` to their checkouts.

## Threat model / abuse path closed

**Before:** fork contributor opens PR with malicious code in `package.json` scripts or `.github/actions/version-bumping/*/action.yml` → `build-dist` runs `npm test`/`npm run build` with `contents: write` GITHUB_TOKEN available → arbitrary API calls can push branches, modify files, or create releases on the base repo.

**After:** fork code only executes in `build-test-core` where the token is `contents: read` and not stored in the git credential helper. The `contents: write` job (`commit-dist`) runs only trusted steps against the pre-built artifact and never runs for fork PRs.

## Type of Change

- [x] CI/CD changes

## Compatibility Analysis

No behavioural change for same-repo PRs or push/schedule runs. For fork PRs, CodeQL SARIF is no longer uploaded to the base repo's security dashboard (analysis still runs and gates the PR). The build/test pipeline produces the same outputs; only the permission boundaries between jobs change.