### PR TITLE
docs: warn about GITHUB_TOKEN limitation for status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ with:
 | Input | Description | Default | Required |
 | :--- | :--- | :--- | :--- |
 | `type` | **Required**. Project type to bump (`maven`, `npm`, `python`, `version-file`, `helm`). | | Yes |
-| `token` | **Required**. GitHub token. | | Yes |
+| `token` | **Required**. GitHub token with permission to fetch PR status and commit changes. See [note on `GITHUB_TOKEN`](#github_token-and-status-checks) below. | | Yes |
 | `dry-run` | If true, skip git checkout, pull, and push. | `false` | No |
 | `default-branch` | Override default branch for version fetching (only effective when dry-run is true). | | No |
 | `bump-command` | Custom command to update version. | (auto) | No |
@@ -64,9 +64,27 @@ with:
 
 ### Outputs
 
-- `bumped`: True if version was bumped
-- `new-version`: The new version number
-- `bumpLevel`: The computed SemVer bump level (`major`, `minor`, or `patch`)
+* `bumped`: True if version was bumped
+* `new-version`: The new version number
+* `bumpLevel`: The computed SemVer bump level (`major`, `minor`, or `patch`)
+
+### `GITHUB_TOKEN` and Status Checks
+
+> ⚠️ **Important:** When you pass `secrets.GITHUB_TOKEN` as the `token` input,
+> commits pushed by this action are made by the `github-actions[bot]` identity.
+> GitHub intentionally does **not** re-trigger other workflow runs for such pushes
+> (to prevent infinite loops), so your other status checks (CI, tests, linting,
+> etc.) will **not** run on the version-bump commit.
+>
+> **To have other workflows re-run on the bump commit**, pass a
+> [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+> or a
+> [GitHub App token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app)
+> instead:
+>
+> ```yaml
+> token: ${{ secrets.MY_PAT }}
+> ```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pull Request Semver Bumper
 
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/pull-request-semver-bumper)](https://api.reuse.software/info/github.com/SAP/pull-request-semver-bumper)
+[![Latest Release](https://img.shields.io/github/v/release/SAP/pull-request-semver-bumper)](https://github.com/SAP/pull-request-semver-bumper/releases/latest)
 
 ## About this project
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,15 @@ inputs:
     description: "Project type to bump (maven, npm, python, version-file, helm)"
     required: true
   token:
-    description: "GitHub token with permission to fetch PR status and commit changes"
+    description: |
+      GitHub token with permission to fetch PR status and commit changes.
+      ⚠️ Using the default `secrets.GITHUB_TOKEN` means commits pushed by this
+      action are made by the `github-actions[bot]` identity. GitHub intentionally
+      does not re-trigger other workflow runs for such pushes (to prevent infinite
+      loops), so your other status checks (CI, tests, etc.) will NOT run on the
+      version-bump commit.
+      To have other workflows re-run, pass a Personal Access Token (PAT) or a
+      GitHub App token instead of `secrets.GITHUB_TOKEN`.
     required: true
   dry-run:
     description: "If true, skip git checkout, pull, and push"


### PR DESCRIPTION
## Summary

Documents a known GitHub platform limitation: when consumers pass `secrets.GITHUB_TOKEN` as the `token` input, commits pushed by this action are made by the `github-actions[bot]` identity, and GitHub intentionally does **not** re-trigger other workflow runs on such pushes. This means CI checks, tests, linting, and other status checks will not run on the version-bump commit.

## Changes Made

- **`action.yml`**: Expanded `token` input description to include an inline warning about the `GITHUB_TOKEN` limitation and guidance to use a PAT or GitHub App token instead.
- **`README.md`**: Added a dedicated `GITHUB_TOKEN and Status Checks` section under Inputs with a clear warning, explanation, and code example for using a PAT.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
